### PR TITLE
Fix wrong projection output

### DIFF
--- a/vision_mamba/model.py
+++ b/vision_mamba/model.py
@@ -95,7 +95,7 @@ class VisionEncoderMambaBlock(nn.Module):
 
         # Split x into x1 and x2 with linears
         z1 = self.proj(x)
-        x1 = self.proj(x)
+        x = self.proj(x)
 
         # forward con1d
         x1 = self.process_direction(


### PR DESCRIPTION
- Description: change projection output variable from `x1` to `x`, which apply projection layer correctly.
- Issue: The projection layer was not applied to input x before forward and backward process. 
- Tag maintainer:  @kye@apac.ai